### PR TITLE
chore(volta): volta hooks 配置不能同时满足 windows 和 macos

### DIFF
--- a/.volta/hooks.json
+++ b/.volta/hooks.json
@@ -4,7 +4,7 @@
             "prefix": "https://cdn.npmmirror.com/binaries/node/"
         },
         "distro": {
-            "template": "https://registry.npmmirror.com/-/binary/node/v{{version}}/node-v{{version}}-{{os}}-{{arch}}.zip"
+            "template": "https://registry.npmmirror.com/-/binary/node/v{{version}}/node-v{{version}}-{{os}}-{{arch}}.{{ext}}"
         }
     },
     "npm": {


### PR DESCRIPTION
fix #203